### PR TITLE
Updated ff crate to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fffft"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["kwantam <kwantam@gmail.com>"]
 edition = "2018"
 description = "Number theoretic transform for PrimeField types (from ff crate)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fffft"
-version = "0.6.0"
+version = "0.5.0"
 authors = ["kwantam <kwantam@gmail.com>"]
 edition = "2018"
 description = "Number theoretic transform for PrimeField types (from ff crate)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fffft"
-version = "0.4.2"
+version = "0.6.0"
 authors = ["kwantam <kwantam@gmail.com>"]
 edition = "2018"
 description = "Number theoretic transform for PrimeField types (from ff crate)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ repository = "https://github.com/kwantam/fffft"
 
 [dependencies]
 err-derive = "0.2"
-ff = "0.12"
+ff = "0.13"
 itertools = "0.10"
 rayon = "1.5"
 
 [dev-dependencies]
 bitvec = "1.0.1"
 byteorder = "1"
-ff = { version = "0.12", features = ["derive"] }
+ff = { version = "0.13", features = ["derive"] }
 rand = "0.8"
 rand_core = "0.6"
 rug = "1"

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ This crate contains a blanket trait impl for [ff::PrimeField].
 
 - 0.4.0: Update deps. Add new functions that use precomputed roots of unity.
 
-- 0.5.0: Update deps (`ff` 0.10 => 0.12; `bitvec` 0.22 => 1.0.1)
-
-- 0.6.0: Update `ff` to 0.13, no API changes.
+- 0.5.0: Update deps (`ff` 0.10 => 0.13; `bitvec` 0.22 => 1.0.1)
 
 ## license
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This crate contains a blanket trait impl for [ff::PrimeField].
 
 - 0.4.1: Update deps.
 
+- 0.4.2: Update `ff` to 0.13, no API changes.
+
 ## license
 
     Copyright 2020 Riad S. Wahby

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This crate contains a blanket trait impl for [ff::PrimeField].
 
 - 0.4.0: Update deps. Add new functions that use precomputed roots of unity.
 
-- 0.4.1: Update deps.
+- 0.5.0: Update deps (`ff` 0.10 => 0.12; `bitvec` 0.22 => 1.0.1)
 
-- 0.4.2: Update `ff` to 0.13, no API changes.
+- 0.6.0: Update `ff` to 0.13, no API changes.
 
 ## license
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ fn roots_of_unity<T: Field>(mut root: T, log_len: u32, rdeg: u32) -> Vec<T> {
 
     // early exit for short inputs
     if log_len - 1 <= LOG_PAR_LIMIT {
-        return iterate(T::ONE.clone(), |&v| v * root)
+        return iterate(T::ONE, |&v| v * root)
             .take(1 << (log_len - 1))
             .collect();
     }
@@ -325,7 +325,7 @@ fn rou_rec<T: Field>(out: &mut [T], log_roots: &[T]) {
 
     // base case: just compute the roots sequentially
     if log_roots.len() <= LOG_PAR_LIMIT as usize {
-        out[0] = T::ONE.clone();
+        out[0] = T::ONE;
         for idx in 1..out.len() {
             out[idx] = out[idx - 1] * log_roots[0];
         }
@@ -358,7 +358,7 @@ fn roots_of_unity_ser<T: Field>(mut root: T, log_len: u32, rdeg: u32) -> Vec<T> 
         root *= root;
     }
 
-    iterate(T::ONE.clone(), |&v| v * root)
+    iterate(T::ONE, |&v| v * root)
         .take(1 << (log_len - 1))
         .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl<T: ff::PrimeField> FieldFFT for T {
     const S: u32 = <Self as ff::PrimeField>::S;
 
     fn root_of_unity() -> Self {
-        <Self as ff::PrimeField>::root_of_unity()
+        <Self as ff::PrimeField>::ROOT_OF_UNITY
     }
 }
 
@@ -303,7 +303,7 @@ fn roots_of_unity<T: Field>(mut root: T, log_len: u32, rdeg: u32) -> Vec<T> {
 
     // early exit for short inputs
     if log_len - 1 <= LOG_PAR_LIMIT {
-        return iterate(T::one(), |&v| v * root)
+        return iterate(T::ONE.clone(), |&v| v * root)
             .take(1 << (log_len - 1))
             .collect();
     }
@@ -325,7 +325,7 @@ fn rou_rec<T: Field>(out: &mut [T], log_roots: &[T]) {
 
     // base case: just compute the roots sequentially
     if log_roots.len() <= LOG_PAR_LIMIT as usize {
-        out[0] = T::one();
+        out[0] = T::ONE.clone();
         for idx in 1..out.len() {
             out[idx] = out[idx - 1] * log_roots[0];
         }
@@ -358,7 +358,7 @@ fn roots_of_unity_ser<T: Field>(mut root: T, log_len: u32, rdeg: u32) -> Vec<T> 
         root *= root;
     }
 
-    iterate(T::one(), |&v| v * root)
+    iterate(T::ONE.clone(), |&v| v * root)
         .take(1 << (log_len - 1))
         .collect()
 }
@@ -452,7 +452,7 @@ fn derange<T>(xi: &mut [T], log_len: u32) {
 }
 
 fn n_inv<T: Field>(log_len: u32) -> T {
-    let mut tmp = <T as Field>::one();
+    let mut tmp = <T as Field>::ONE;
     for _ in 0..log_len {
         tmp = tmp.double();
     }


### PR DESCRIPTION
ff 0.13 adds nice functionality like `from_u128` to field element to avoid having to convert ints to strings and then field elements. 

All tests are passing locally. 